### PR TITLE
DebugMenu: Fix checking if a submenu has values

### DIFF
--- a/Hell2024/Hell2024/src/Core/DebugMenu.cpp
+++ b/Hell2024/Hell2024/src/Core/DebugMenu.cpp
@@ -522,9 +522,9 @@ const int DebugMenu::GetSubMenuItemCount() {
 	return _currentMenuItem->subMenu.size();
 }
 
-const bool DebugMenu::SubMenuHasValues() {	
-	for (int i = 0; i << _currentMenuItem->subMenu.size(); i++) {
-		if (_currentMenuItem->subMenu[i].flag !=MenuItemFlag::UNDEFINED) {
+const bool DebugMenu::SubMenuHasValues() {
+	for (const auto& subMenuItem : _currentMenuItem->subMenu) {
+		if (subMenuItem.flag != MenuItemFlag::UNDEFINED) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Instead of checking if the index was less than the size of the submenu, it would left-shift the index by the size and check if it wasn't zero. This fixes that, and uses a for-each-loop instead of a normal for-loop.