### PR TITLE
Fix: Strip UTF-8 BOM from included shaders (Issue #32)

### DIFF
--- a/Hell2025/Hell2025/src/API/OpenGL/Types/GL_shader.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Types/GL_shader.cpp
@@ -272,8 +272,17 @@ void ParseFile(const std::string& filepath, std::string& outputString, std::vect
     std::ifstream file(filepath);
     std::string line;
     int lineNumber = 0;
+    bool isFirstLine = true;
     bool versionInserted = false;
     while (std::getline(file, line)) {
+
+
+        if (isFirstLine)
+        {
+            line = StripBOM(line);
+            isFirstLine = false;
+        }
+
         // Handle includes
         if (line.find("#include") != std::string::npos) {
             size_t start = line.find("\"") + 1;


### PR DESCRIPTION
### Overview :
This PR fixes the **_garbage character_** errors encountered during shader compilation on some  OpenGL drivers.

**The Problem :** 
The previous _StripBOM_ implementation only cleaned the top-level shader file. However, many shaders  use #include directives (e.g., util.glsl). If these included files contain a UTF-8 Byte Order Mark (BOM), the include parsing logic would inject those invisible bytes into the middle of the final source string. 

**The Fix :** 
I added the _StripBOM_ method call in the recursive _ParseFile_ loop. This ensures that every file, whether it is the main entry point or an included utility is cleaned of the BOM immediately upon being read.

### Verification :

**Hardware :** 
- Intel UHD Graphics 630
- GPU Memory : 3.9 GB (Shared UMA)

**Result:** Previously, the engine would crash during shader compilation with "invalid character" errors. With this change, the shaders now compile successfully.

_**Note:** While my specific hardware hits a VRAM limit later in the run process, I have confirmed the shader compilation stage  is now fully functional._

Closes #32