### PR TITLE
Fix foundational timing, GI state, and core correctness bugs

### DIFF
--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -1,0 +1,26 @@
+name: Windows MSVC Build
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build Hell2025.sln (Release|x64)
+        shell: pwsh
+        run: |
+          msbuild "Hell2025/Hell2025.sln" /m /t:Build /p:Configuration=Release /p:Platform=x64 /verbosity:minimal

--- a/Hell2025/Hell2025/src/API/OpenGL/GL_backEnd.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/GL_backEnd.cpp
@@ -94,6 +94,9 @@ namespace OpenGLBackEnd {
     }
 
     void OpenGLBackEnd::UploadVertexData(std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+        if (vertices.empty() || indices.empty()) {
+            return;
+        }
 
         if (g_vertexDataVAO != 0) {
             glDeleteVertexArrays(1, &g_vertexDataVAO);
@@ -107,9 +110,9 @@ namespace OpenGLBackEnd {
 
         glBindVertexArray(g_vertexDataVAO);
         glBindBuffer(GL_ARRAY_BUFFER, g_vertexDataVBO);
-        glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(Vertex), &vertices[0], GL_STATIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(Vertex), vertices.data(), GL_STATIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_vertexDataEBO);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint32_t), &indices[0], GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint32_t), indices.data(), GL_STATIC_DRAW);
 
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)0);
@@ -143,9 +146,9 @@ namespace OpenGLBackEnd {
 
         glBindVertexArray(g_weightedVertexDataVAO);
         glBindBuffer(GL_ARRAY_BUFFER, g_weightedVertexDataVBO);
-        glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(WeightedVertex), &vertices[0], GL_STATIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(WeightedVertex), vertices.data(), GL_STATIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_weightedVertexDataEBO);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint32_t), &indices[0], GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint32_t), indices.data(), GL_STATIC_DRAW);
 
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(WeightedVertex), (void*)0);

--- a/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_compute_ftt.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_compute_ftt.cpp
@@ -56,7 +56,6 @@ namespace OpenGLRenderer {
 
         if (doTime) {
             g_globalTime += deltaTime;
-            g_globalTime += deltaTime;
         }
         else {
             g_globalTime = 50.0f;

--- a/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_compute_skinning.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_compute_skinning.cpp
@@ -51,14 +51,31 @@ namespace OpenGLRenderer {
         for (const RenderItem& renderItem : RenderDataManager::GetSkinnedRenderItems()) {
             uint32_t meshIndex = renderItem.meshIndex;
             SkinnedMesh* mesh = AssetManager::GetSkinnedMeshByIndex(meshIndex);
-            if (!mesh) {
+            if (!mesh || mesh->vertexCount == 0) {
+                continue;
+            }
+
+            const int32_t baseTransformIndex = renderItem.baseSkinningTransformIndex;
+            if (baseTransformIndex < 0 || static_cast<size_t>(baseTransformIndex) >= skinningTransforms.size()) {
+                continue;
+            }
+
+            uint64_t objectId = 0;
+            Util::UnpackUint64(renderItem.objectIdLowerBit, renderItem.objectIdUpperBit, objectId);
+            AnimatedGameObject* animatedGameObject = World::GetAnimatedGameObjectByObjectId(objectId);
+            if (!animatedGameObject) {
+                continue;
+            }
+
+            const size_t boneCount = animatedGameObject->GetBoneSkinningMatrices().size();
+            if (boneCount == 0 || static_cast<size_t>(baseTransformIndex) + boneCount > skinningTransforms.size()) {
                 continue;
             }
 
             shader->SetInt("vertexCount", mesh->vertexCount);
             shader->SetInt("baseInputVertex", mesh->baseVertexGlobal);
             shader->SetInt("baseOutputVertex", renderItem.baseSkinnedVertex);
-            shader->SetInt("baseTransformIndex", renderItem.baseSkinningTransformIndex);
+            shader->SetInt("baseTransformIndex", baseTransformIndex);
 
             GLuint workgroupSize = 128;
             GLuint groupCountX = (mesh->vertexCount + workgroupSize - 1) / workgroupSize;

--- a/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_compute_skinning.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_compute_skinning.cpp
@@ -45,11 +45,15 @@ namespace OpenGLRenderer {
         shader->Bind();
 
         const std::vector<glm::mat4>& skinningTransforms = RenderDataManager::GetSkinningTransforms();
-        skinningTransformsSSBO->Update(skinningTransforms.size() * sizeof(glm::mat4), &skinningTransforms[0]);
+        const void* skinningTransformData = skinningTransforms.empty() ? nullptr : skinningTransforms.data();
+        skinningTransformsSSBO->Update(skinningTransforms.size() * sizeof(glm::mat4), skinningTransformData);
 
         for (const RenderItem& renderItem : RenderDataManager::GetSkinnedRenderItems()) {
             uint32_t meshIndex = renderItem.meshIndex;
             SkinnedMesh* mesh = AssetManager::GetSkinnedMeshByIndex(meshIndex);
+            if (!mesh) {
+                continue;
+            }
 
             shader->SetInt("vertexCount", mesh->vertexCount);
             shader->SetInt("baseInputVertex", mesh->baseVertexGlobal);

--- a/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_global_illumination_passes.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_global_illumination_passes.cpp
@@ -32,6 +32,9 @@ namespace OpenGLRenderer {
 
         OpenGLSSBO* pointGridBufferSSBO = GetSSBO("PointGridBuffer");
         OpenGLSSBO* pointIndicesBufferSSBO = GetSSBO("PointIndicesBuffer");
+        if (!triangleDataSSBO || !sceneBvhSSBO || !meshesBvhSSBO || !entityInstancesSSBO || !lightsSSBO || !pointGridBufferSSBO || !pointIndicesBufferSSBO) {
+            return;
+        }
         
         uint64_t sceneBvhId = GlobalIllumination::GetSceneBvhId();
 
@@ -42,12 +45,19 @@ namespace OpenGLRenderer {
         std::vector<PointCloudOctrant>& pointCloudOctrants = GlobalIllumination::GetPointCloudOctrants();
         std::vector<unsigned int>& pointIndices = GlobalIllumination::GetPointIndices();
 
-        UpdateSSBO("SceneBvh", sceneNodes.size() * sizeof(BvhNode), &sceneNodes[0]);
-        UpdateSSBO("MeshesBvh", meshBvhNodes.size() * sizeof(BvhNode), &meshBvhNodes[0]);
-        UpdateSSBO("EntityInstances", entityInstances.size() * sizeof(GpuPrimitiveInstance), &entityInstances[0]);
-        UpdateSSBO("TriangleData", triData.size() * sizeof(float), &triData[0]);
-        UpdateSSBO("PointGridBuffer", pointCloudOctrants.size() * sizeof(PointCloudOctrant), &pointCloudOctrants[0]);
-        UpdateSSBO("PointIndicesBuffer", pointIndices.size() * sizeof(unsigned int), &pointIndices[0]);
+        const void* sceneNodeData = sceneNodes.empty() ? nullptr : sceneNodes.data();
+        const void* meshBvhNodeData = meshBvhNodes.empty() ? nullptr : meshBvhNodes.data();
+        const void* entityInstanceData = entityInstances.empty() ? nullptr : entityInstances.data();
+        const void* triDataPtr = triData.empty() ? nullptr : triData.data();
+        const void* pointCloudOctrantData = pointCloudOctrants.empty() ? nullptr : pointCloudOctrants.data();
+        const void* pointIndexData = pointIndices.empty() ? nullptr : pointIndices.data();
+
+        UpdateSSBO("SceneBvh", sceneNodes.size() * sizeof(BvhNode), sceneNodeData);
+        UpdateSSBO("MeshesBvh", meshBvhNodes.size() * sizeof(BvhNode), meshBvhNodeData);
+        UpdateSSBO("EntityInstances", entityInstances.size() * sizeof(GpuPrimitiveInstance), entityInstanceData);
+        UpdateSSBO("TriangleData", triData.size() * sizeof(float), triDataPtr);
+        UpdateSSBO("PointGridBuffer", pointCloudOctrants.size() * sizeof(PointCloudOctrant), pointCloudOctrantData);
+        UpdateSSBO("PointIndicesBuffer", pointIndices.size() * sizeof(unsigned int), pointIndexData);
 
         //std::cout << "pointCloudOctrants.size(): " << pointCloudOctrants.size() << "\n";
         //std::cout << "pointIndices.size(): " << pointIndices.size() << "\n";
@@ -68,7 +78,7 @@ namespace OpenGLRenderer {
             glGenBuffers(1, &g_pointCloudVbo);
         }
 
-        std::vector<CloudPoint>& pointCloud = GlobalIllumination::GetPointClound();
+        std::vector<CloudPoint>& pointCloud = GlobalIllumination::GetPointCloud();
         std::vector<PointCloudOctrant>& pointCloudOctrants = GlobalIllumination::GetPointCloudOctrants();
         std::vector<unsigned int>& pointIndics = GlobalIllumination::GetPointIndices();
 
@@ -104,7 +114,7 @@ namespace OpenGLRenderer {
         shader->Bind();
         shader->SetInt("u_lightCount", World::GetLightCount());
 
-        GLuint numGroupsX = (GlobalIllumination::GetPointClound().size() + 127) / 128;
+        GLuint numGroupsX = (GlobalIllumination::GetPointCloud().size() + 127) / 128;
 
         glDispatchCompute(numGroupsX, 1, 1);
         glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
@@ -150,7 +160,7 @@ namespace OpenGLRenderer {
         glDisable(GL_CULL_FACE);
         glDisable(GL_BLEND);
 
-        std::vector<CloudPoint>& pointCloud = GlobalIllumination::GetPointClound();
+        std::vector<CloudPoint>& pointCloud = GlobalIllumination::GetPointCloud();
         int pointCloudCount = pointCloud.size();
 
         for (int i = 0; i < 4; i++) {

--- a/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_tile_passes.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Renderer/ComputePasses/GL_tile_passes.cpp
@@ -61,7 +61,8 @@ namespace OpenGLRenderer {
             g_gpuLights.insert(g_gpuLights.end(), gpuLights.begin(), gpuLights.end());
         }
 
-        UpdateSSBO("ChristmasLightInstances", g_gpuLights.size() * sizeof(GPUChristmasLight), (void*)&g_gpuLights[0]);
+        const void* christmasLightData = g_gpuLights.empty() ? nullptr : g_gpuLights.data();
+        UpdateSSBO("ChristmasLightInstances", g_gpuLights.size() * sizeof(GPUChristmasLight), christmasLightData);
         glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
         // Debug draw the lights as points

--- a/Hell2025/Hell2025/src/API/OpenGL/Renderer/GL_renderer.cpp
+++ b/Hell2025/Hell2025/src/API/OpenGL/Renderer/GL_renderer.cpp
@@ -425,7 +425,8 @@ namespace OpenGLRenderer {
 
     void UpdateSSBOS() {
         const std::vector<GLuint64>& bindlessTextureIDs = OpenGLBackEnd::GetBindlessTextureIDs();
-        g_ssbos["Samplers"].Update(bindlessTextureIDs.size() * sizeof(GLuint64), (void*)&bindlessTextureIDs[0]);
+        const void* bindlessTextureData = bindlessTextureIDs.empty() ? nullptr : bindlessTextureIDs.data();
+        g_ssbos["Samplers"].Update(bindlessTextureIDs.size() * sizeof(GLuint64), bindlessTextureData);
         g_ssbos["Samplers"].Bind(0);
 
         const RendererData& rendererData = RenderDataManager::GetRendererData();
@@ -433,19 +434,23 @@ namespace OpenGLRenderer {
         g_ssbos["RendererData"].Bind(1);
 
         const std::vector<ViewportData>& playerData = RenderDataManager::GetViewportData();
-        g_ssbos["ViewportData"].Update(playerData.size() * sizeof(ViewportData), (void*)&playerData[0]);
+        const void* playerDataPtr = playerData.empty() ? nullptr : playerData.data();
+        g_ssbos["ViewportData"].Update(playerData.size() * sizeof(ViewportData), playerDataPtr);
         g_ssbos["ViewportData"].Bind(2);
 
         const std::vector<RenderItem>& instanceData = RenderDataManager::GetInstanceData();
-        g_ssbos["InstanceData"].Update(instanceData.size() * sizeof(RenderItem), (void*)&instanceData[0]);
+        const void* instanceDataPtr = instanceData.empty() ? nullptr : instanceData.data();
+        g_ssbos["InstanceData"].Update(instanceData.size() * sizeof(RenderItem), instanceDataPtr);
         g_ssbos["InstanceData"].Bind(3);
 
         const std::vector<GPULight>& gpuLightsHighRes = RenderDataManager::GetGPULightsHighRes();
-        g_ssbos["Lights"].Update(gpuLightsHighRes.size() * sizeof(GPULight), (void*)&gpuLightsHighRes[0]);
+        const void* lightsDataPtr = gpuLightsHighRes.empty() ? nullptr : gpuLightsHighRes.data();
+        g_ssbos["Lights"].Update(gpuLightsHighRes.size() * sizeof(GPULight), lightsDataPtr);
         g_ssbos["Lights"].Bind(4);
 
         const std::vector<BloodDecalInstanceData>& screenSpaceBloodDecalInstances = RenderDataManager::GetScreenSpaceBloodDecalInstanceData();
-        g_ssbos["BloodDecalInstances"].Update(screenSpaceBloodDecalInstances.size() * sizeof(BloodDecalInstanceData), (void*)&screenSpaceBloodDecalInstances[0]);
+        const void* bloodDecalDataPtr = screenSpaceBloodDecalInstances.empty() ? nullptr : screenSpaceBloodDecalInstances.data();
+        g_ssbos["BloodDecalInstances"].Update(screenSpaceBloodDecalInstances.size() * sizeof(BloodDecalInstanceData), bloodDecalDataPtr);
 
 
         GLuint zero = 0;
@@ -453,11 +458,12 @@ namespace OpenGLRenderer {
         UpdateSSBO("BloodDecalCounter", sizeof(uint32_t), &zero);
         UpdateSSBO("ChristmasLightCounter", sizeof(uint32_t), &zero);
 
-        g_ssbos["BloodDecalInstances"].Update(screenSpaceBloodDecalInstances.size() * sizeof(BloodDecalInstanceData), (void*)&screenSpaceBloodDecalInstances[0]);
+        g_ssbos["BloodDecalInstances"].Update(screenSpaceBloodDecalInstances.size() * sizeof(BloodDecalInstanceData), bloodDecalDataPtr);
 
 
         const std::vector<glm::mat4>& oceanPatchTransforms = RenderDataManager::GetOceanPatchTransforms();
-        UpdateSSBO("OceanPatchTransforms", oceanPatchTransforms.size() * sizeof(glm::mat4), (void*)&oceanPatchTransforms[0]);
+        const void* oceanPatchTransformData = oceanPatchTransforms.empty() ? nullptr : oceanPatchTransforms.data();
+        UpdateSSBO("OceanPatchTransforms", oceanPatchTransforms.size() * sizeof(glm::mat4), oceanPatchTransformData);
 
         glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
     }

--- a/Hell2025/Hell2025/src/AssetManagement/AssetManager_animation.cpp
+++ b/Hell2025/Hell2025/src/AssetManagement/AssetManager_animation.cpp
@@ -3,6 +3,7 @@
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
+#include <algorithm>
 #include <future>
 
 namespace AssetManager {
@@ -22,66 +23,81 @@ namespace AssetManager {
     void LoadAnimation(Animation* animation) {
         const FileInfo& fileInfo = animation->GetFileInfo();
 
-        aiScene* m_pAnimationScene;
         Assimp::Importer m_AnimationImporter;
 
         // Try and load the animation
-        const aiScene* tempAnimScene = m_AnimationImporter.ReadFile(fileInfo.path.c_str(), aiProcess_Triangulate | aiProcess_GenSmoothNormals | aiProcess_FlipUVs);
+        const aiScene* animationScene = m_AnimationImporter.ReadFile(fileInfo.path.c_str(), aiProcess_Triangulate | aiProcess_GenSmoothNormals | aiProcess_FlipUVs);
 
         // Failed
-        if (!tempAnimScene) {
+        if (!animationScene) {
             std::cout << "Could not load: " << fileInfo.path << "\n";
+            animation->SetLoadingState(LoadingState::Value::LOADING_COMPLETE);
             return;
         }
 
-        // Success
-        m_pAnimationScene = new aiScene(*tempAnimScene);
-        if (m_pAnimationScene) {
-            if (m_pAnimationScene->mNumAnimations == 0) {
-                std::cout << "ATTENTION! " << animation->GetName() << " has zero animations\n";
-            }
-            else {
-                animation->m_duration = (float)m_pAnimationScene->mAnimations[0]->mDuration;
-                animation->m_ticksPerSecond = (float)m_pAnimationScene->mAnimations[0]->mTicksPerSecond;
-                //std::cout << "Loaded animation: " << Filename << "\n";
-            }
+        if (animationScene->mNumAnimations == 0 || animationScene->mAnimations[0] == nullptr) {
+            std::cout << "ATTENTION! " << animation->GetName() << " has zero animations\n";
+            m_AnimationImporter.FreeScene();
+            animation->SetLoadingState(LoadingState::Value::LOADING_COMPLETE);
+            return;
         }
-        // Some other error possibility
-        else {
-            std::cout << "Error parsing " << fileInfo.path << ": " << m_AnimationImporter.GetErrorString();
-        }
+
+        animation->m_duration = (float)animationScene->mAnimations[0]->mDuration;
+        animation->m_ticksPerSecond = (float)animationScene->mAnimations[0]->mTicksPerSecond;
 
         // need to create an animation clip.
         // need to fill it with animation poses.
-        aiAnimation* aiAnim = m_pAnimationScene->mAnimations[0];
+        aiAnimation* aiAnim = animationScene->mAnimations[0];
 
         // Resize the vector big enough for each pose
-        int nodeCount = aiAnim->mNumChannels;
+        int nodeCount = (int)aiAnim->mNumChannels;
          // trying the assimp way now. coz why fight it.
         for (int n = 0; n < nodeCount; n++)
         {
+            if (!aiAnim->mChannels[n]) {
+                continue;
+            }
+
             const char* nodeName = Util::CopyConstChar(aiAnim->mChannels[n]->mNodeName.C_Str());
 
             AnimatedNode animatedNode(nodeName);
             animation->m_NodeMapping.emplace(nodeName, n);
 
-            //for (unsigned int p = 0; p < aiAnim->mChannels[n]->mNumPositionKeys; p++)
-            unsigned int numPosKeys = aiAnim->mChannels[n]->mNumPositionKeys;
-            unsigned int numRotKeys = aiAnim->mChannels[n]->mNumRotationKeys;
-            unsigned int numScaleKeys = aiAnim->mChannels[n]->mNumScalingKeys;
+            const aiNodeAnim* channel = aiAnim->mChannels[n];
+            unsigned int numPosKeys = channel->mNumPositionKeys;
+            unsigned int numRotKeys = channel->mNumRotationKeys;
+            unsigned int numScaleKeys = channel->mNumScalingKeys;
             unsigned int keyCount = std::max({ numPosKeys, numRotKeys, numScaleKeys });
+
+            if (keyCount == 0) {
+                continue;
+            }
 
             for (unsigned int p = 0; p < keyCount; ++p)
             {
                 SQT sqt;
-                aiVectorKey pos = aiAnim->mChannels[n]->mPositionKeys[p];
-                aiQuatKey rot = aiAnim->mChannels[n]->mRotationKeys[p];
-                aiVectorKey scale = aiAnim->mChannels[n]->mScalingKeys[p];
+                sqt.positon = glm::vec3(0.0f);
+                sqt.rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+                sqt.scale = glm::vec3(1.0f);
+                sqt.timeStamp = 0.0f;
 
-                sqt.positon = glm::vec3(pos.mValue.x, pos.mValue.y, pos.mValue.z);
-                sqt.rotation = glm::quat(rot.mValue.w, rot.mValue.x, rot.mValue.y, rot.mValue.z);
-                sqt.scale = glm::vec3(scale.mValue.x, scale.mValue.y, scale.mValue.z);
-                sqt.timeStamp = (float)pos.mTime;
+                if (numPosKeys > 0) {
+                    const aiVectorKey& pos = channel->mPositionKeys[std::min(p, numPosKeys - 1)];
+                    sqt.positon = glm::vec3(pos.mValue.x, pos.mValue.y, pos.mValue.z);
+                    sqt.timeStamp = (float)pos.mTime;
+                }
+
+                if (numRotKeys > 0) {
+                    const aiQuatKey& rot = channel->mRotationKeys[std::min(p, numRotKeys - 1)];
+                    sqt.rotation = glm::quat(rot.mValue.w, rot.mValue.x, rot.mValue.y, rot.mValue.z);
+                    sqt.timeStamp = std::max(sqt.timeStamp, (float)rot.mTime);
+                }
+
+                if (numScaleKeys > 0) {
+                    const aiVectorKey& scale = channel->mScalingKeys[std::min(p, numScaleKeys - 1)];
+                    sqt.scale = glm::vec3(scale.mValue.x, scale.mValue.y, scale.mValue.z);
+                    sqt.timeStamp = std::max(sqt.timeStamp, (float)scale.mTime);
+                }
 
                 // not good: sqt.positon = Util::SanitizeVec3(sqt.positon);
                 // not good: sqt.rotation = Util::SanitizeQuat(sqt.rotation);

--- a/Hell2025/Hell2025/src/AssetManagement/AssetManager_mesh.cpp
+++ b/Hell2025/Hell2025/src/AssetManagement/AssetManager_mesh.cpp
@@ -39,6 +39,11 @@ namespace AssetManager {
     }
 
     int CreateMesh(const std::string& name, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+        if (vertices.empty()) {
+            std::cout << "AssetManager::CreateMesh(\"" << name << "\") failed: vertices was empty\n";
+            return CreateMesh(name, vertices, indices, glm::vec3(0.0f), glm::vec3(0.0f), -1, glm::mat4(1.0f), glm::mat4(1.0f));
+        }
+
         // Initialize AABB min and max with first vertex
         glm::vec3 aabbMin = vertices[0].position;
         glm::vec3 aabbMax = vertices[0].position;

--- a/Hell2025/Hell2025/src/BackEnd/BackEnd.cpp
+++ b/Hell2025/Hell2025/src/BackEnd/BackEnd.cpp
@@ -151,18 +151,16 @@ namespace BackEnd {
     }
 
     void UpdateGame() {
-        const Resolutions& resolutions = Config::GetResolutions();
-
-        float deltaTime = Game::GetDeltaTime();
-
         ViewportManager::Update();
+
+        AStarMap::Update();
+        Game::Update();
+        float deltaTime = Game::GetDeltaTime();
 
         if (Editor::IsOpen()) {
             Editor::Update(deltaTime);
         }
 
-        AStarMap::Update();
-        Game::Update();
         MirrorManager::Update();
 
         Physics::UpdateAllRigidDynamics(deltaTime);

--- a/Hell2025/Hell2025/src/Bvh/Cpu/CpuBvh.cpp
+++ b/Hell2025/Hell2025/src/Bvh/Cpu/CpuBvh.cpp
@@ -7,6 +7,7 @@
 #include "Timer.hpp"
 
 #include <iostream>
+#include <algorithm>
 #include <unordered_map>
 
 #include "bvh/v2/bvh.h"
@@ -331,13 +332,13 @@ namespace Bvh::Cpu {
 
 		// Walk the scene BVH and create the GPU primitive instance array, specifically ordering them such that leaf node instances are adjacent
 		sceneBvh.m_gpuInstances.reserve(instances.size());
-		uint32_t stack[MAX_BVH_STACK_SIZE];
-		size_t stack_size = 0;
-		uint32_t rootNodeIndex = 0;
-		stack[stack_size++] = rootNodeIndex;
+		std::vector<uint32_t> stack;
+		stack.reserve(std::max<size_t>(MAX_BVH_STACK_SIZE, sceneBvh.m_nodes.size()));
+		stack.push_back(0);
 
-		while (stack_size != 0) {
-			uint32_t currentIndex = stack[--stack_size];
+		while (!stack.empty()) {
+			uint32_t currentIndex = stack.back();
+			stack.pop_back();
 			BvhNode& node = sceneBvh.m_nodes[currentIndex];
 
 			// If this node is a leaf...
@@ -353,7 +354,14 @@ namespace Bvh::Cpu {
 
 					// Create the GPU primitive instance
 					GpuPrimitiveInstance& gpuInstance = sceneBvh.m_gpuInstances.emplace_back();
-					gpuInstance.rootNodeIndex = g_meshBvhRootNodeOffsetMapping[instance.meshBvhId];
+					auto rootNodeOffsetIt = g_meshBvhRootNodeOffsetMapping.find(instance.meshBvhId);
+					if (rootNodeOffsetIt != g_meshBvhRootNodeOffsetMapping.end()) {
+						gpuInstance.rootNodeIndex = rootNodeOffsetIt->second;
+					}
+					else {
+						std::cout << "Warning: missing mesh BVH root mapping for meshBvhId " << instance.meshBvhId << "\n";
+						gpuInstance.rootNodeIndex = 0;
+					}
 					gpuInstance.worldTransform = instance.worldTransform;
 					gpuInstance.inverseWorldTransform = instance.inverseWorldTransform;
 					gpuInstance.openableId = instance.openableId;
@@ -366,8 +374,8 @@ namespace Bvh::Cpu {
 				node.firstChildOrPrimitive = newPrimitiveIndex;
 			}
 			else {
-				stack[stack_size++] = node.firstChildOrPrimitive;
-				stack[stack_size++] = node.firstChildOrPrimitive + 1;
+				stack.push_back(node.firstChildOrPrimitive);
+				stack.push_back(node.firstChildOrPrimitive + 1);
 			}
 		}
 	}
@@ -426,7 +434,7 @@ namespace Bvh::Cpu {
 	}
 
 	glm::vec3 BvhVec3ToGlmVec3(MadmannVec3 vec) {
-		return { vec.values[0], vec.values[2], vec.values[2] };
+		return { vec.values[0], vec.values[1], vec.values[2] };
 	}
 
 	MadmannVec3 GlmVec3ToBvhVec3(glm::vec3 vec) {

--- a/Hell2025/Hell2025/src/Bvh/Gpu/Bvh.cpp
+++ b/Hell2025/Hell2025/src/Bvh/Gpu/Bvh.cpp
@@ -7,6 +7,7 @@
 #include "Timer.hpp"
 
 #include <iostream>
+#include <algorithm>
 #include <unordered_map>
 
 #include "bvh/v2/bvh.h"
@@ -274,13 +275,13 @@ namespace Bvh::Gpu {
         sceneBvh.m_gpuInstances.reserve(instances.size());
 
         // Walk the scene BVH and create the entity instance array, specifically ordering them such that leaf node instances are adjacent
-        uint32_t stack[MAX_BVH_STACK_SIZE];
-        size_t stack_size = 0;
-        uint32_t rootNodeIndex = 0;
-        stack[stack_size++] = rootNodeIndex;
+        std::vector<uint32_t> stack;
+        stack.reserve(std::max<size_t>(MAX_BVH_STACK_SIZE, sceneBvh.m_nodes.size()));
+        stack.push_back(0);
 
-        while (stack_size != 0) {
-            uint32_t currentIndex = stack[--stack_size];
+        while (!stack.empty()) {
+            uint32_t currentIndex = stack.back();
+            stack.pop_back();
             BvhNode& node = sceneBvh.m_nodes[currentIndex];
 
             // If this node is a leaf...
@@ -296,7 +297,14 @@ namespace Bvh::Gpu {
 
                     // Create the GPU primitive instance
                     GpuPrimitiveInstance& gpuInstance = sceneBvh.m_gpuInstances.emplace_back();
-                    gpuInstance.rootNodeIndex = g_meshBvhRootNodeOffsetMapping[instance.meshBvhId];
+                    auto rootNodeOffsetIt = g_meshBvhRootNodeOffsetMapping.find(instance.meshBvhId);
+                    if (rootNodeOffsetIt != g_meshBvhRootNodeOffsetMapping.end()) {
+                        gpuInstance.rootNodeIndex = rootNodeOffsetIt->second;
+                    }
+                    else {
+                        std::cout << "Warning: missing mesh BVH root mapping for meshBvhId " << instance.meshBvhId << "\n";
+                        gpuInstance.rootNodeIndex = 0;
+                    }
                     gpuInstance.worldTransform = instance.worldTransform;
                     gpuInstance.inverseWorldTransform = glm::inverse(gpuInstance.worldTransform);
                     gpuInstance.openableId = instance.openableId;
@@ -308,8 +316,8 @@ namespace Bvh::Gpu {
                 node.firstChildOrPrimitive = newPrimitiveIndex;
             }
             else {
-                stack[stack_size++] = node.firstChildOrPrimitive;
-                stack[stack_size++] = node.firstChildOrPrimitive + 1;
+                stack.push_back(node.firstChildOrPrimitive);
+                stack.push_back(node.firstChildOrPrimitive + 1);
             }
         }
     }
@@ -367,7 +375,7 @@ namespace Bvh::Gpu {
     }
 
     glm::vec3 BvhVec3ToGlmVec3(MadmannVec3 vec) {
-        return { vec.values[0], vec.values[2], vec.values[2] };
+        return { vec.values[0], vec.values[1], vec.values[2] };
     }
 
     MadmannVec3 GlmVec3ToBvhVec3(glm::vec3 vec) {

--- a/Hell2025/Hell2025/src/Editor/Editor_objects.cpp
+++ b/Hell2025/Hell2025/src/Editor/Editor_objects.cpp
@@ -189,7 +189,7 @@ namespace Editor {
 
             if (Piano* piano = World::GetPianoByObjectId(GetSelectedObjectId())) {
                 Gizmo::SetPosition(piano->GetPosition());
-                Gizmo::SetRotation(piano->GetPosition());
+                Gizmo::SetRotation(piano->GetRotation());
             }
 
             if (PickUp* pickup = World::GetPickUpByObjectId(GetSelectedObjectId())) {

--- a/Hell2025/Hell2025/src/File/AssimpImporter.cpp
+++ b/Hell2025/Hell2025/src/File/AssimpImporter.cpp
@@ -289,15 +289,16 @@ namespace AssimpImporter {
             bool allVerticeHaveOnlyOneWeight = true;
 
             for (WeightedVertex& vertex : meshData.vertices) {
-                if (vertex.weight.y != 0 &&
-                    vertex.weight.z != 0 &&
+                if (vertex.weight.y != 0 ||
+                    vertex.weight.z != 0 ||
                     vertex.weight.w != 0) {
                     allVerticeHaveOnlyOneWeight = false;
+                    break;
                 }
             }
 
             // If they do, now check they all reference the same bone
-            int foundBoneIndex = meshData.vertices[0].boneID[0];
+            int foundBoneIndex = meshData.vertices.empty() ? -1 : meshData.vertices[0].boneID[0];
             bool allVerticesAlsoOnlyReferenceTheSameBone = true;
 
             if (allVerticeHaveOnlyOneWeight) {

--- a/Hell2025/Hell2025/src/File/File.cpp
+++ b/Hell2025/Hell2025/src/File/File.cpp
@@ -203,7 +203,9 @@ SkinnedModelData File::ImportSkinnedModel(const std::string& filepath) {
 
     // Read the name
     std::string modelName(skinnedModelHeader.nameLength, '\0');
-    file.read(&modelName[0], skinnedModelHeader.nameLength);
+    if (skinnedModelHeader.nameLength > 0) {
+        file.read(&modelName[0], skinnedModelHeader.nameLength);
+    }
 
     #if PRINT_SKINNED_MODEL_HEADERS_ON_READ
     PrintSkinnedModelHeader(skinnedModelHeader, "Read model header: '" + modelName + "'");
@@ -226,7 +228,9 @@ SkinnedModelData File::ImportSkinnedModel(const std::string& filepath) {
         // Read node name
         std::string nodeName;
         nodeName.resize(nodeNameLength);
-        file.read(&nodeName[0], nodeNameLength);
+        if (nodeNameLength > 0) {
+            file.read(&nodeName[0], nodeNameLength);
+        }
 
         // Read parent index
         int parentIndex = 0;
@@ -262,7 +266,9 @@ SkinnedModelData File::ImportSkinnedModel(const std::string& filepath) {
         // Read the bone name into a string
         std::string boneName;
         boneName.resize(nameLength);
-        file.read(&boneName[0], nameLength);
+        if (nameLength > 0) {
+            file.read(&boneName[0], nameLength);
+        }
 
         // Read the corresponding bone index
         unsigned int boneIndex = 0;
@@ -290,7 +296,9 @@ SkinnedModelData File::ImportSkinnedModel(const std::string& filepath) {
 
         // Read the mesh name.
         std::string meshName(nameLength, '\0');
-        file.read(&meshName[0], nameLength);
+        if (nameLength > 0) {
+            file.read(&meshName[0], nameLength);
+        }
 
         // Read the AABB values.
         glm::vec3 aabbMin;

--- a/Hell2025/Hell2025/src/Physics/Physics_util.cpp
+++ b/Hell2025/Hell2025/src/Physics/Physics_util.cpp
@@ -122,6 +122,7 @@ namespace Physics {
         if (result.hitFound) {
             result.hitPosition = glm::vec3(hit.block.position.x, hit.block.position.y, hit.block.position.z);
             result.hitNormal = glm::vec3(hit.block.normal.x, hit.block.normal.y, hit.block.normal.z);
+            result.distanceToHit = glm::distance(rayOrigin, result.hitPosition);
             result.hitFound = true;
             PhysicsUserData* userData = (PhysicsUserData*)hit.block.actor->userData;
             if (userData) {
@@ -325,4 +326,3 @@ namespace Physics {
         }
     }
 }
-

--- a/Hell2025/Hell2025/src/Player/Player_flashlight.cpp
+++ b/Hell2025/Hell2025/src/Player/Player_flashlight.cpp
@@ -69,8 +69,6 @@ void Player::UpdateFlashlight(float deltaTime) {
     m_flashlightPosition = Util::LerpVec3(m_flashlightPosition, flashlightPositionTarget, deltaTime, interSpeed);
     m_flashlightDirection = Util::LerpVec3(m_flashlightDirection, flashlightDirectionTarget, deltaTime, interSpeed);
 
-    m_flashlightPosition = flashlightPositionTarget;
-
     float aspectRatio = 1.0f;
     //if (RenderDataManager::GetViewportData().size()) {
     //    float viewportWidth = RenderDataManager::GetViewportData()[m_viewportIndex].width;

--- a/Hell2025/Hell2025/src/Renderer/GlobalIllumination.cpp
+++ b/Hell2025/Hell2025/src/Renderer/GlobalIllumination.cpp
@@ -10,8 +10,6 @@
 
 namespace GlobalIllumination {
 
-    float g_probeSpacing = 0.75f;
-
     struct Triangle {
         glm::vec3 v0;
         glm::vec3 v1;
@@ -29,51 +27,61 @@ namespace GlobalIllumination {
     inline float RoundUp(float value, float spacing)    { return std::ceil(value / spacing) * spacing; }
     inline float RoundDown(float value, float spacing)  { return std::floor(value / spacing) * spacing; }
 
-    uint64_t g_houseBvhId = 0;
-    uint64_t g_doorBvhId = 0;
-    uint64_t g_sceneBvhId = 0;
+    struct GlobalIlluminationState {
+        float probeSpacing = 0.75f;
 
-    glm::vec3 g_houseMinBounds = glm::vec3(0.0f);
-    glm::vec3 g_houseMaxBounds = glm::vec3(0.0f);
+        uint64_t houseBvhId = 0;
+        uint64_t doorBvhId = 0;
+        uint64_t sceneBvhId = 0;
 
-    std::vector<LightVolume> g_lightVolumes;
-    std::vector<Triangle> g_triangles;
-    std::vector<CloudPoint> g_pointCloud;
-    bool g_globalIlluminationStructuresDirty = false;
-    bool g_pointCloudNeedsGpuUpdate = false;
+        glm::vec3 houseMinBounds = glm::vec3(0.0f);
+        glm::vec3 houseMaxBounds = glm::vec3(0.0f);
 
-    std::vector<PointCloudOctrant> g_pointCloudOctrants;
-    std::vector<unsigned int> g_pointIndices;
-    constexpr float g_pointCloudOctrantSpacing = 5.0f;
-    glm::uvec3 g_pointCloudGridDimensions;
-    glm::vec3 g_pointGridWorldMin;
-    glm::vec3 g_pointGridWorldMax;
-    glm::vec3 g_pointCloudOctrantSize;
+        std::vector<LightVolume> lightVolumes;
+        std::vector<Triangle> triangles;
+        std::vector<CloudPoint> pointCloud;
+        bool globalIlluminationStructuresDirty = false;
+        bool pointCloudNeedsGpuUpdate = false;
+
+        std::vector<PointCloudOctrant> pointCloudOctrants;
+        std::vector<unsigned int> pointIndices;
+        glm::uvec3 pointCloudGridDimensions = glm::uvec3(0);
+        glm::vec3 pointGridWorldMin = glm::vec3(0.0f);
+        glm::vec3 pointGridWorldMax = glm::vec3(0.0f);
+        glm::vec3 pointCloudOctrantSize = glm::vec3(0.0f);
+
+        static constexpr float pointCloudOctrantSpacing = 5.0f;
+    };
+
+    GlobalIlluminationState& GetState() {
+        static GlobalIlluminationState state;
+        return state;
+    }
 
     void Update() {
-        if (g_globalIlluminationStructuresDirty) {
+        if (GetState().globalIlluminationStructuresDirty) {
             GlobalIllumination::CreatePointCloud();
             GlobalIllumination::CreateHouseBvh();
-            if (g_doorBvhId == 0) {
+            if (GetState().doorBvhId == 0) {
                 CreateDoorBvh();
             }
-            if (g_sceneBvhId == 0) {
-                g_sceneBvhId = Bvh::Gpu::CreateNewSceneBvh();
+            if (GetState().sceneBvhId == 0) {
+                GetState().sceneBvhId = Bvh::Gpu::CreateNewSceneBvh();
             }
             Bvh::Gpu::FlatternMeshBvhNodes();
-            g_globalIlluminationStructuresDirty = false;
+            GetState().globalIlluminationStructuresDirty = false;
         }
 
         UpdateSceneBVh();
     }
 
     void CreatePointCloud() {
-        g_triangles.clear();
+        GetState().triangles.clear();
 
         // Store floor and ceilings triangles
         for (HousePlane& plane : World::GetHousePlanes()) {
             for (uint32_t i = 0; i < plane.GetIndices().size(); i+=3) {
-                Triangle& triangle = g_triangles.emplace_back();
+                Triangle& triangle = GetState().triangles.emplace_back();
 
                 int idx0 = plane.GetIndices()[i + 0];
                 int idx1 = plane.GetIndices()[i + 1];
@@ -83,7 +91,11 @@ namespace GlobalIllumination {
                 triangle.v1 = plane.GetVertices()[idx1].position;
                 triangle.v2 = plane.GetVertices()[idx2].position;
 
-                triangle.normal = plane.GetVertices()[i].normal;
+                triangle.normal = normalize(
+                    plane.GetVertices()[idx0].normal +
+                    plane.GetVertices()[idx1].normal +
+                    plane.GetVertices()[idx2].normal
+                );
             }
         }
 
@@ -91,7 +103,7 @@ namespace GlobalIllumination {
         for (Wall& wall : World::GetWalls()) {
             for (WallSegment& wallSegment : wall.GetWallSegments()) {
                 for (uint32_t i = 0; i < wallSegment.GetIndices().size(); i += 3) {
-                    Triangle& triangle = g_triangles.emplace_back();
+                    Triangle& triangle = GetState().triangles.emplace_back();
                     
                     int idx0 = wallSegment.GetIndices()[i + 0];
                     int idx1 = wallSegment.GetIndices()[i + 1];
@@ -110,9 +122,9 @@ namespace GlobalIllumination {
             }
         }
 
-        g_pointCloud.clear();
+        GetState().pointCloud.clear();
 
-        for (Triangle& triangle : g_triangles) {
+        for (Triangle& triangle : GetState().triangles) {
 
             // Make sure normal is valid
             glm::vec3 edge1 = triangle.v1 - triangle.v0;
@@ -146,11 +158,11 @@ namespace GlobalIllumination {
             max.x = RoundUp(max.x, POINT_CLOUD_SPACING) + POINT_CLOUD_SPACING * 0.5f;
             max.y = RoundUp(max.y, POINT_CLOUD_SPACING) + POINT_CLOUD_SPACING * 0.5f;
 
-            float theshold = 0.05f;
-            min.x += theshold;
-            min.y += theshold;
-            max.x -= theshold;
-            max.y -= theshold;
+            float threshold = 0.05f;
+            min.x += threshold;
+            min.y += threshold;
+            max.x -= threshold;
+            max.y -= threshold;
 
             // Generate points within the bounding box
             for (float x = min.x; x <= max.x; x += POINT_CLOUD_SPACING) {
@@ -159,7 +171,7 @@ namespace GlobalIllumination {
                     if (Util::IsPointInTriangle2D(pt, v0_2d, v1_2d, v2_2d)) {
                         glm::vec3 pt3d = triangle.v0 + right * (pt.x - v0_2d.x) + up * (pt.y - v0_2d.y);
 
-                        CloudPoint& cloudPoint = g_pointCloud.emplace_back();
+                        CloudPoint& cloudPoint = GetState().pointCloud.emplace_back();
                         cloudPoint.position = glm::vec4(pt3d, 0.0f);
                         cloudPoint.normal = glm::vec4(triangle.normal, 0.0f);
                     }
@@ -167,23 +179,23 @@ namespace GlobalIllumination {
             }
         }
 
-        g_pointCloudNeedsGpuUpdate = true;
+        GetState().pointCloudNeedsGpuUpdate = true;
 
-        std::cout << "Recreated point cloud: " << g_pointCloud.size() << " points \n";
+        std::cout << "Recreated point cloud: " << GetState().pointCloud.size() << " points \n";
     }
 
     void CreateHouseBvh() {     
         // Destroy any previous house bvh
-        if (g_houseBvhId != 0) {
-            Bvh::Gpu::DestroyMeshBvh(g_houseBvhId);
+        if (GetState().houseBvhId != 0) {
+            Bvh::Gpu::DestroyMeshBvh(GetState().houseBvhId);
         }
 
-        g_houseMinBounds = glm::vec3(std::numeric_limits<float>::max());
-        g_houseMaxBounds = glm::vec3(-std::numeric_limits<float>::max());
+        GetState().houseMinBounds = glm::vec3(std::numeric_limits<float>::max());
+        GetState().houseMaxBounds = glm::vec3(-std::numeric_limits<float>::max());
 
         // Create house vertices
         std::vector<Vertex> vertices;
-        for (Triangle& triangle : g_triangles) {
+        for (Triangle& triangle : GetState().triangles) {
             Vertex v0, v1, v2;
             v0.position = triangle.v0;
             v1.position = triangle.v1;
@@ -191,47 +203,47 @@ namespace GlobalIllumination {
             v0.normal = triangle.normal;
             v1.normal = triangle.normal;
             v2.normal = triangle.normal;
-            vertices.push_back(triangle.v0);
-            vertices.push_back(triangle.v1);
-            vertices.push_back(triangle.v2);
+            vertices.push_back(v0);
+            vertices.push_back(v1);
+            vertices.push_back(v2);
 
-            g_houseMinBounds.x = std::min(g_houseMinBounds.x, v0.position.x);
-            g_houseMinBounds.y = std::min(g_houseMinBounds.y, v0.position.y);
-            g_houseMinBounds.z = std::min(g_houseMinBounds.z, v0.position.z);
-            g_houseMaxBounds.x = std::max(g_houseMaxBounds.x, v0.position.x);
-            g_houseMaxBounds.y = std::max(g_houseMaxBounds.y, v0.position.y);
-            g_houseMaxBounds.z = std::max(g_houseMaxBounds.z, v0.position.z);
+            GetState().houseMinBounds.x = std::min(GetState().houseMinBounds.x, v0.position.x);
+            GetState().houseMinBounds.y = std::min(GetState().houseMinBounds.y, v0.position.y);
+            GetState().houseMinBounds.z = std::min(GetState().houseMinBounds.z, v0.position.z);
+            GetState().houseMaxBounds.x = std::max(GetState().houseMaxBounds.x, v0.position.x);
+            GetState().houseMaxBounds.y = std::max(GetState().houseMaxBounds.y, v0.position.y);
+            GetState().houseMaxBounds.z = std::max(GetState().houseMaxBounds.z, v0.position.z);
 
-            g_houseMinBounds.x = std::min(g_houseMinBounds.x, v1.position.x);
-            g_houseMinBounds.y = std::min(g_houseMinBounds.y, v1.position.y);
-            g_houseMinBounds.z = std::min(g_houseMinBounds.z, v1.position.z);
-            g_houseMaxBounds.x = std::max(g_houseMaxBounds.x, v1.position.x);
-            g_houseMaxBounds.y = std::max(g_houseMaxBounds.y, v1.position.y);
-            g_houseMaxBounds.z = std::max(g_houseMaxBounds.z, v1.position.z);
+            GetState().houseMinBounds.x = std::min(GetState().houseMinBounds.x, v1.position.x);
+            GetState().houseMinBounds.y = std::min(GetState().houseMinBounds.y, v1.position.y);
+            GetState().houseMinBounds.z = std::min(GetState().houseMinBounds.z, v1.position.z);
+            GetState().houseMaxBounds.x = std::max(GetState().houseMaxBounds.x, v1.position.x);
+            GetState().houseMaxBounds.y = std::max(GetState().houseMaxBounds.y, v1.position.y);
+            GetState().houseMaxBounds.z = std::max(GetState().houseMaxBounds.z, v1.position.z);
 
-            g_houseMinBounds.x = std::min(g_houseMinBounds.x, v2.position.x);
-            g_houseMinBounds.y = std::min(g_houseMinBounds.y, v2.position.y);
-            g_houseMinBounds.z = std::min(g_houseMinBounds.z, v2.position.z);
-            g_houseMaxBounds.x = std::max(g_houseMaxBounds.x, v2.position.x);
-            g_houseMaxBounds.y = std::max(g_houseMaxBounds.y, v2.position.y);
-            g_houseMaxBounds.z = std::max(g_houseMaxBounds.z, v2.position.z);
+            GetState().houseMinBounds.x = std::min(GetState().houseMinBounds.x, v2.position.x);
+            GetState().houseMinBounds.y = std::min(GetState().houseMinBounds.y, v2.position.y);
+            GetState().houseMinBounds.z = std::min(GetState().houseMinBounds.z, v2.position.z);
+            GetState().houseMaxBounds.x = std::max(GetState().houseMaxBounds.x, v2.position.x);
+            GetState().houseMaxBounds.y = std::max(GetState().houseMaxBounds.y, v2.position.y);
+            GetState().houseMaxBounds.z = std::max(GetState().houseMaxBounds.z, v2.position.z);
         }
 
         // Create house indices
         std::vector<uint32_t> indices(vertices.size());
-        for (int i = 0; i < vertices.size(); i++) {
-            indices[i] = i;
+        for (size_t i = 0; i < vertices.size(); i++) {
+            indices[i] = static_cast<uint32_t>(i);
         }
 
-        g_houseBvhId = Bvh::Gpu::CreateMeshBvhFromVertexData(vertices, indices);
+        GetState().houseBvhId = Bvh::Gpu::CreateMeshBvhFromVertexData(vertices, indices);
 
         // For now you only have one light volume, for whatever house you just made.
-        for (LightVolume& lightVolume : g_lightVolumes) {
+        for (LightVolume& lightVolume : GetState().lightVolumes) {
             lightVolume.CleanUp();
         }
-        g_lightVolumes.clear();
-        LightVolume& lightVolume = g_lightVolumes.emplace_back();
-        lightVolume.Init(vertices, g_houseMinBounds, g_houseMaxBounds);
+        GetState().lightVolumes.clear();
+        LightVolume& lightVolume = GetState().lightVolumes.emplace_back();
+        lightVolume.Init(vertices, GetState().houseMinBounds, GetState().houseMaxBounds);
 
         InitPointGrid();
     }
@@ -253,30 +265,33 @@ namespace GlobalIllumination {
             indices[i] = i;
         }
 
-        g_doorBvhId = Bvh::Gpu::CreateMeshBvhFromVertexData(vertices, indices);
+        GetState().doorBvhId = Bvh::Gpu::CreateMeshBvhFromVertexData(vertices, indices);
     }
     
     void UpdateSceneBVh() {
-        return;
+        if (GetState().sceneBvhId == 0 || GetState().houseBvhId == 0) {
+            return;
+        }
 
         std::vector<PrimitiveInstance> instances;
+        instances.reserve(1 + World::GetDoors().size());
 
         // Add the house
         PrimitiveInstance& instance = instances.emplace_back();
-        instance.worldAabbBoundsMin.x = g_houseMinBounds.x;
-        instance.worldAabbBoundsMin.y = g_houseMinBounds.y;
-        instance.worldAabbBoundsMin.z = g_houseMinBounds.z;
-        instance.worldAabbBoundsMax.x = g_houseMaxBounds.x;
-        instance.worldAabbBoundsMax.y = g_houseMaxBounds.y;
-        instance.worldAabbBoundsMax.z = g_houseMaxBounds.z;
+        instance.worldAabbBoundsMin.x = GetState().houseMinBounds.x;
+        instance.worldAabbBoundsMin.y = GetState().houseMinBounds.y;
+        instance.worldAabbBoundsMin.z = GetState().houseMinBounds.z;
+        instance.worldAabbBoundsMax.x = GetState().houseMaxBounds.x;
+        instance.worldAabbBoundsMax.y = GetState().houseMaxBounds.y;
+        instance.worldAabbBoundsMax.z = GetState().houseMaxBounds.z;
         instance.objectId = 0;
         instance.worldTransform = glm::mat4(1.0f);
-        instance.meshBvhId = g_houseBvhId;
+        instance.meshBvhId = GetState().houseBvhId;
         instance.worldAabbCenter = (instance.worldAabbBoundsMin + instance.worldAabbBoundsMax) * 0.5f;
 
         // Add all the doors
-        int objectId = 1;
         for (Door& door : World::GetDoors()) {
+            (void)door;
             // BROKKEN BECAUSE OF physicsId now gone
             //uint64_t rigidStaticId = door.GetPhysicsId();
             //RigidStatic* rigidStatic = Physics::GetRigidStaitcById(rigidStaticId);
@@ -293,152 +308,151 @@ namespace GlobalIllumination {
             //instance.worldAabbBoundsMax.x = maxBounds.x;
             //instance.worldAabbBoundsMax.y = maxBounds.y;
             //instance.worldAabbBoundsMax.z = maxBounds.z;
-            //instance.objectId = objectId;// door.GetObjectId();
+            //instance.objectId = door.GetObjectId();
             //instance.worldTransform = door.GetDoorModelMatrix();
-            //instance.meshBvhId = g_doorBvhId;
+            //instance.meshBvhId = GetState().doorBvhId;
             //instance.worldAabbCenter = (instance.worldAabbBoundsMin + instance.worldAabbBoundsMax) * 0.5f;
-            //objectId++;
         }
 
-        Bvh::Gpu::UpdateSceneBvh(g_sceneBvhId, instances);
+        Bvh::Gpu::UpdateSceneBvh(GetState().sceneBvhId, instances);
     }
 
     void InitPointGrid() {
 
-        for (LightVolume& lightVolume : g_lightVolumes) {
+        for (LightVolume& lightVolume : GetState().lightVolumes) {
 
-            g_pointGridWorldMin = lightVolume.m_offset;
-            g_pointGridWorldMax = lightVolume.m_offset + glm::vec3(lightVolume.m_worldSpaceWidth, lightVolume.m_worldSpaceHeight, lightVolume.m_worldSpaceDepth);
+            GetState().pointGridWorldMin = lightVolume.m_offset;
+            GetState().pointGridWorldMax = lightVolume.m_offset + glm::vec3(lightVolume.m_worldSpaceWidth, lightVolume.m_worldSpaceHeight, lightVolume.m_worldSpaceDepth);
 
-            glm::vec3 worldSize = g_pointGridWorldMax - g_pointGridWorldMin;
-            g_pointCloudGridDimensions.x = static_cast<unsigned int>(glm::ceil(worldSize.x / g_pointCloudOctrantSpacing));
-            g_pointCloudGridDimensions.y = static_cast<unsigned int>(glm::ceil(worldSize.y / g_pointCloudOctrantSpacing));
-            g_pointCloudGridDimensions.z = static_cast<unsigned int>(glm::ceil(worldSize.z / g_pointCloudOctrantSpacing));
+            glm::vec3 worldSize = GetState().pointGridWorldMax - GetState().pointGridWorldMin;
+            GetState().pointCloudGridDimensions.x = static_cast<unsigned int>(glm::ceil(worldSize.x / GlobalIlluminationState::pointCloudOctrantSpacing));
+            GetState().pointCloudGridDimensions.y = static_cast<unsigned int>(glm::ceil(worldSize.y / GlobalIlluminationState::pointCloudOctrantSpacing));
+            GetState().pointCloudGridDimensions.z = static_cast<unsigned int>(glm::ceil(worldSize.z / GlobalIlluminationState::pointCloudOctrantSpacing));
 
-            g_pointCloudOctrantSize = worldSize / glm::vec3(g_pointCloudGridDimensions);
+            GetState().pointCloudOctrantSize = worldSize / glm::vec3(GetState().pointCloudGridDimensions);
 
              // Bail if point cloud is empty
-            if (g_pointCloud.empty()) return;
+            if (GetState().pointCloud.empty()) return;
 
             // For each grid cell, count how many points fall inside it
-            unsigned int totalCells = g_pointCloudGridDimensions.x * g_pointCloudGridDimensions.y * g_pointCloudGridDimensions.z;
+            unsigned int totalCells = GetState().pointCloudGridDimensions.x * GetState().pointCloudGridDimensions.y * GetState().pointCloudGridDimensions.z;
             std::vector<unsigned int> cellCounts(totalCells, 0);
 
-            for (const auto& point : g_pointCloud) {
+            for (const auto& point : GetState().pointCloud) {
                 // Find out which grid cell this point belongs to
-                glm::vec3 relativePos = glm::vec3(point.position) - g_pointGridWorldMin;
-                glm::ivec3 cellCoords = glm::ivec3(relativePos / g_pointCloudOctrantSize);
+                glm::vec3 relativePos = glm::vec3(point.position) - GetState().pointGridWorldMin;
+                glm::ivec3 cellCoords = glm::ivec3(relativePos / GetState().pointCloudOctrantSize);
 
                 // Make sure the coordinates are within the grid bounds, just in case
-                cellCoords = glm::clamp(cellCoords, glm::ivec3(0), glm::ivec3(g_pointCloudGridDimensions) - 1);
+                cellCoords = glm::clamp(cellCoords, glm::ivec3(0), glm::ivec3(GetState().pointCloudGridDimensions) - 1);
 
                 // Convert the 3D cell coordinate into a 1D array index and increment the counter
-                unsigned int cellIndex = (cellCoords.z * g_pointCloudGridDimensions.x * g_pointCloudGridDimensions.y) + (cellCoords.y * g_pointCloudGridDimensions.x) + cellCoords.x;
+                unsigned int cellIndex = (cellCoords.z * GetState().pointCloudGridDimensions.x * GetState().pointCloudGridDimensions.y) + (cellCoords.y * GetState().pointCloudGridDimensions.x) + cellCoords.x;
                 cellCounts[cellIndex]++;
             }
 
             // Create the final PointGridCell structures with the correct offsets
-            g_pointCloudOctrants.resize(totalCells);
+            GetState().pointCloudOctrants.resize(totalCells);
             unsigned int currentOffset = 0;
             for (unsigned int i = 0; i < totalCells; ++i) {
-                g_pointCloudOctrants[i].m_cloudPointCount = cellCounts[i];
-                g_pointCloudOctrants[i].m_offset = currentOffset;
+                GetState().pointCloudOctrants[i].m_cloudPointCount = cellCounts[i];
+                GetState().pointCloudOctrants[i].m_offset = currentOffset;
                 currentOffset += cellCounts[i]; // The next cell's offset starts after all of this cell's points
             }
 
             // Finally, we create the master list of sorted point indices
-            g_pointIndices.resize(g_pointCloud.size());
+            GetState().pointIndices.resize(GetState().pointCloud.size());
             std::vector<unsigned int> tempOffsets(totalCells);
             for (unsigned int i = 0; i < totalCells; ++i) {
-                tempOffsets[i] = g_pointCloudOctrants[i].m_offset;
+                tempOffsets[i] = GetState().pointCloudOctrants[i].m_offset;
             }
 
             // Go through the original points again...
-            for (unsigned int i = 0; i < g_pointCloud.size(); ++i) {
-                const auto& point = g_pointCloud[i];
+            for (unsigned int i = 0; i < GetState().pointCloud.size(); ++i) {
+                const auto& point = GetState().pointCloud[i];
 
                 // Find which cell it belongs to...
-                glm::vec3 relativePos = glm::vec3(point.position) - g_pointGridWorldMin;
-                glm::ivec3 cellCoords = glm::ivec3(relativePos / g_pointCloudOctrantSize);
-                cellCoords = glm::clamp(cellCoords, glm::ivec3(0), glm::ivec3(g_pointCloudGridDimensions) - 1);
-                unsigned int cellIndex = (cellCoords.z * g_pointCloudGridDimensions.x * g_pointCloudGridDimensions.y) + (cellCoords.y * g_pointCloudGridDimensions.x) + cellCoords.x;
+                glm::vec3 relativePos = glm::vec3(point.position) - GetState().pointGridWorldMin;
+                glm::ivec3 cellCoords = glm::ivec3(relativePos / GetState().pointCloudOctrantSize);
+                cellCoords = glm::clamp(cellCoords, glm::ivec3(0), glm::ivec3(GetState().pointCloudGridDimensions) - 1);
+                unsigned int cellIndex = (cellCoords.z * GetState().pointCloudGridDimensions.x * GetState().pointCloudGridDimensions.y) + (cellCoords.y * GetState().pointCloudGridDimensions.x) + cellCoords.x;
 
                 // Use the write counter to place the point's original index i in the correct slot
                 unsigned int& insertionIndex = tempOffsets[cellIndex];
-                g_pointIndices[insertionIndex] = i;
+                GetState().pointIndices[insertionIndex] = i;
 
                 // Increment the write counter for that cell
                 insertionIndex++;
             }
         }
         std::cout << "Point cloud octrant grid created\n";
-        std::cout << "g_pointIndices:       " << g_pointIndices.size() << "\n";
-        std::cout << "g_pointCloudOctrants: " << g_pointCloudOctrants.size() << "\n";
+        std::cout << "pointIndices:       " << GetState().pointIndices.size() << "\n";
+        std::cout << "pointCloudOctrants: " << GetState().pointCloudOctrants.size() << "\n";
         
     }
 
     uint64_t GetSceneBvhId() {
-        return g_sceneBvhId;
+        return GetState().sceneBvhId;
     }
 
     const std::vector<BvhNode>& GetSceneNodes() {
         static std::vector<BvhNode> empty;
-        if (g_sceneBvhId == 0) {
+        if (GetState().sceneBvhId == 0) {
             return empty;
         }
 
-        SceneBvh* sceneBvh = Bvh::Gpu::GetSceneBvhById(g_sceneBvhId);
+        SceneBvh* sceneBvh = Bvh::Gpu::GetSceneBvhById(GetState().sceneBvhId);
         if (!sceneBvh) return empty;
 
         return sceneBvh->m_nodes;
     }
 
-    std::vector<CloudPoint>& GetPointClound() {
-        return g_pointCloud;
+    std::vector<CloudPoint>& GetPointCloud() {
+        return GetState().pointCloud;
     }
 
     std::vector<LightVolume>& GetLightVolumes() {
-        return g_lightVolumes;
+        return GetState().lightVolumes;
     }
 
     void SetGlobalIlluminationStructuresDirtyState(bool state) {
-        g_globalIlluminationStructuresDirty = state;
+        GetState().globalIlluminationStructuresDirty = state;
     }
 
     bool GlobalIlluminationStructuresAreDirty() {
-        return g_globalIlluminationStructuresDirty;
+        return GetState().globalIlluminationStructuresDirty;
     }
 
     void SetPointCloudNeedsGpuUpdateState(bool state) {
-        g_pointCloudNeedsGpuUpdate = state;
+        GetState().pointCloudNeedsGpuUpdate = state;
     }
 
     bool PointCloudNeedsGpuUpdate() {
-        return g_pointCloudNeedsGpuUpdate;
+        return GetState().pointCloudNeedsGpuUpdate;
     }
 
     float GetProbeSpacing() {
-        return g_probeSpacing;
+        return GetState().probeSpacing;
     }
 
     std::vector<PointCloudOctrant>& GetPointCloudOctrants() {
-        return g_pointCloudOctrants;
+        return GetState().pointCloudOctrants;
     }
 
     std::vector<unsigned int>& GetPointIndices() {
-        return g_pointIndices;
+        return GetState().pointIndices;
     }
 
     glm::uvec3 GetPointCloudGridDimensions() {
-        return g_pointCloudGridDimensions;
+        return GetState().pointCloudGridDimensions;
     }
 
     glm::vec3 GetPointGridWorldMin() {
-        return g_pointGridWorldMin;
+        return GetState().pointGridWorldMin;
     }
 
     glm::vec3 GetPointGridWorldMax() {
-        return g_pointGridWorldMax;
+        return GetState().pointGridWorldMax;
     }
 }
 

--- a/Hell2025/Hell2025/src/Renderer/GlobalIllumination.h
+++ b/Hell2025/Hell2025/src/Renderer/GlobalIllumination.h
@@ -49,7 +49,7 @@ namespace GlobalIllumination {
 
     uint64_t GetSceneBvhId();
     const std::vector<BvhNode>& GetSceneNodes();
-    std::vector<CloudPoint>& GetPointClound();
+    std::vector<CloudPoint>& GetPointCloud();
     std::vector<LightVolume>& GetLightVolumes();
     std::vector<PointCloudOctrant>& GetPointCloudOctrants();
     std::vector<unsigned int>& GetPointIndices();

--- a/Hell2025/Hell2025/src/Renderer/RenderDataManager.cpp
+++ b/Hell2025/Hell2025/src/Renderer/RenderDataManager.cpp
@@ -570,7 +570,11 @@ namespace RenderDataManager {
 
         for (const RenderItem& renderItem : renderItems) {
             SkinnedMesh* mesh = AssetManager::GetSkinnedMeshByIndex(renderItem.meshIndex);
-            std::size_t index = commands.size();
+            if (!mesh) {
+                instanceOffset++;
+                continue;
+            }
+
             auto& cmd = commands.emplace_back();
             cmd.indexCount = mesh->indexCount;
             cmd.firstIndex = mesh->baseIndex;
@@ -586,7 +590,11 @@ namespace RenderDataManager {
 
         for (const RenderItem& renderItem : renderItems) {
             SkinnedMesh* mesh = AssetManager::GetSkinnedMeshByIndex(renderItem.meshIndex);
-            std::size_t index = commands.size();
+            if (!mesh) {
+                instanceOffset++;
+                continue;
+            }
+
             auto& cmd = commands.emplace_back();
             cmd.indexCount = mesh->indexCount;
             cmd.firstIndex = mesh->baseIndex;
@@ -606,38 +614,49 @@ namespace RenderDataManager {
         // Create the transforms buffer
         std::unordered_map<uint64_t, uint32_t> transformIndexMap; // Maps an AnimatedGameObject Id to its base transform index
         uint32_t baseTransformIndex = 0;
+        int32_t baseSkinnedVertex = 0;
+        std::vector<RenderItem> validSkinnedRenderItems;
+        validSkinnedRenderItems.reserve(g_skinnedRenderItems.size());
 
-        for (RenderItem& renderItem : g_skinnedRenderItems) {
+        for (RenderItem renderItem : g_skinnedRenderItems) {
             uint64_t id = 0;
             Util::UnpackUint64(renderItem.objectIdLowerBit, renderItem.objectIdUpperBit, id);
 
             AnimatedGameObject* animatedGameObject = World::GetAnimatedGameObjectByObjectId(id);
-            if (!animatedGameObject) continue;
+            if (!animatedGameObject) {
+                continue;
+            }
+
+            const std::vector<glm::mat4>& boneSkinningMatrices = animatedGameObject->GetBoneSkinningMatrices();
+            if (boneSkinningMatrices.empty()) {
+                continue;
+            }
+
+            SkinnedMesh* mesh = AssetManager::GetSkinnedMeshByIndex(renderItem.meshIndex);
+            if (!mesh || mesh->vertexCount == 0) {
+                continue;
+            }
 
             // Add the id if aint in the map yet
             if (transformIndexMap.find(id) == transformIndexMap.end()) {
                 transformIndexMap[id] = baseTransformIndex;
 
                 // Append skinning matrices to global array
-                g_skinningTransforms.insert(g_skinningTransforms.end(), animatedGameObject->GetBoneSkinningMatrices().begin(), animatedGameObject->GetBoneSkinningMatrices().end());
+                g_skinningTransforms.insert(g_skinningTransforms.end(), boneSkinningMatrices.begin(), boneSkinningMatrices.end());
 
                 // Set the base transform index for the next animated game object
-                baseTransformIndex = g_skinningTransforms.size();
+                baseTransformIndex = static_cast<uint32_t>(g_skinningTransforms.size());
             }
 
             // Update render item with the base transform index
-            renderItem.baseSkinningTransformIndex = transformIndexMap[id];
-        }
-
-        // Set their base vertices
-        int baseSkinnedVertex = 0;
-        for (RenderItem& renderItem : g_skinnedRenderItems) {
-            SkinnedMesh* mesh = AssetManager::GetSkinnedMeshByIndex(renderItem.meshIndex);
-            if (!mesh) continue;
+            renderItem.baseSkinningTransformIndex = static_cast<int32_t>(transformIndexMap[id]);
 
             renderItem.baseSkinnedVertex = baseSkinnedVertex;
-            baseSkinnedVertex += mesh->vertexCount;
+            baseSkinnedVertex += static_cast<int32_t>(mesh->vertexCount);
+            validSkinnedRenderItems.push_back(renderItem);
         }
+
+        g_skinnedRenderItems.swap(validSkinnedRenderItems);
 
         // Create the per viewport draw commands
         for (int i = 0; i < 4; i++) {

--- a/Hell2025/Hell2025/src/Types/Animation/Animator.cpp
+++ b/Hell2025/Hell2025/src/Types/Animation/Animator.cpp
@@ -296,6 +296,7 @@ void Animator::UpdateAnimation(AnimationLayer& animationLayer, float deltaTime) 
 float Animator::GetAnimationTimeInTicks(AnimationLayer& animationState) {
     Animation* animation = animationState.m_animation;
     if (!animation) return 0;
+    if (animation->m_duration <= 0.0f) return 0;
 
     float ticksPerSecond = animation->m_ticksPerSecond != 0 ? animation->m_ticksPerSecond : 25.0f;
     float timeInTicks = animationState.m_currentTime * ticksPerSecond;

--- a/Hell2025/Hell2025/src/Types/Game/AnimatedGameObject.cpp
+++ b/Hell2025/Hell2025/src/Types/Game/AnimatedGameObject.cpp
@@ -208,8 +208,21 @@ void AnimatedGameObject::Update(float deltaTime) {
     // Compute local bone matrices
     int boneCount = m_skinnedModel->GetBoneCount();
     m_boneSkinningMatrices.resize(boneCount);
+
+    const int nodeTransformCount = (int)m_animator.m_globalBlendedNodeTransforms.size();
+    const int boneNodeIndexCount = (int)m_skinnedModel->m_boneNodeIndices.size();
+    const int boneOffsetCount = (int)m_skinnedModel->m_boneOffsets.size();
+
     for (int b = 0; b < boneCount; ++b) {
+        if (b >= boneNodeIndexCount || b >= boneOffsetCount) {
+            continue;
+        }
+
         int nodeIdx = m_skinnedModel->m_boneNodeIndices[b];
+        if (nodeIdx < 0 || nodeIdx >= nodeTransformCount) {
+            continue;
+        }
+
         m_boneSkinningMatrices[b] = m_animator.m_globalBlendedNodeTransforms[nodeIdx] * m_skinnedModel->m_boneOffsets[b];
     }
 

--- a/Hell2025/Hell2025/src/Types/Game/AnimatedGameObject.cpp
+++ b/Hell2025/Hell2025/src/Types/Game/AnimatedGameObject.cpp
@@ -96,7 +96,13 @@ void AnimatedGameObject::UpdateRenderItems() {
 
                 // Update the model matrix to include the animated bone transform
                 int boneIndex = mesh->nonDeformingBoneIndex;
-                renderItem.modelMatrix = GetModelMatrix() * m_boneSkinningMatrices[boneIndex];
+                const int boneMatrixCount = static_cast<int>(m_boneSkinningMatrices.size());
+                if (boneIndex >= 0 && boneIndex < boneMatrixCount) {
+                    renderItem.modelMatrix = GetModelMatrix() * m_boneSkinningMatrices[boneIndex];
+                }
+                else {
+                    renderItem.modelMatrix = GetModelMatrix();
+                }
                 renderItem.inverseModelMatrix = glm::inverse(renderItem.modelMatrix);
 
 

--- a/Hell2025/Hell2025/src/Types/Renderer/MeshNodes.cpp
+++ b/Hell2025/Hell2025/src/Types/Renderer/MeshNodes.cpp
@@ -212,11 +212,9 @@ bool MeshNodes::MeshNodeIsOpen(const std::string& meshName) {
     if (!meshNode) return false;
 
     if (Openable* openable = OpenableManager::GetOpenableByOpenableId(meshNode->openableId)) {
-        if (openable->IsOpen()) {
-            return false;
-        }
+        return openable->IsOpen();
     }
-    return true;
+    return false;
 }
 
 bool MeshNodes::MeshNodeIsClosed(const std::string& meshName) {
@@ -224,11 +222,9 @@ bool MeshNodes::MeshNodeIsClosed(const std::string& meshName) {
     if (!meshNode) return false;
 
     if (Openable* openable = OpenableManager::GetOpenableByOpenableId(meshNode->openableId)) {
-        if (openable->IsClosed()) {
-            return false;
-        }
+        return openable->IsClosed();
     }
-    return true;
+    return false;
 }
 
 bool MeshNodes::MeshNodeIsStatic(int localNodeIndex) {

--- a/Hell2025/Hell2025/src/Util/Util_animation.cpp
+++ b/Hell2025/Hell2025/src/Util/Util_animation.cpp
@@ -15,6 +15,10 @@ namespace Util {
     }
 
     int FindAnimatedNodeIndex(float AnimationTime, const AnimatedNode* animatedNode) {
+        if (!animatedNode || animatedNode->m_nodeKeys.empty()) {
+            return -1;
+        }
+
         // bail if current animation time is earlier than the this nodes first keyframe time
         if (AnimationTime < animatedNode->m_nodeKeys[0].timeStamp)
             return -1; // you WERE returning -1 here
@@ -27,6 +31,11 @@ namespace Util {
     }
 
     void CalcInterpolatedPosition(glm::vec3& Out, float AnimationTime, const AnimatedNode* animatedNode) {
+        if (!animatedNode || animatedNode->m_nodeKeys.empty()) {
+            Out = glm::vec3(0.0f);
+            return;
+        }
+
         int Index = FindAnimatedNodeIndex(AnimationTime, animatedNode);
         int NextIndex = (Index + 1);
 
@@ -42,6 +51,10 @@ namespace Util {
             return;
         }
         float DeltaTime = animatedNode->m_nodeKeys[NextIndex].timeStamp - animatedNode->m_nodeKeys[Index].timeStamp;
+        if (DeltaTime == 0.0f) {
+            Out = animatedNode->m_nodeKeys[Index].positon;
+            return;
+        }
         float Factor = (AnimationTime - animatedNode->m_nodeKeys[Index].timeStamp) / DeltaTime;
 
         glm::vec3 start = animatedNode->m_nodeKeys[Index].positon;
@@ -51,6 +64,11 @@ namespace Util {
     }
 
     void CalcInterpolatedScale(glm::vec3& Out, float AnimationTime, const AnimatedNode* animatedNode) {
+        if (!animatedNode || animatedNode->m_nodeKeys.empty()) {
+            Out = glm::vec3(1.0f);
+            return;
+        }
+
         int Index = FindAnimatedNodeIndex(AnimationTime, animatedNode);
         int NextIndex = (Index + 1);
 
@@ -66,6 +84,10 @@ namespace Util {
             return;
         }
         float DeltaTime = animatedNode->m_nodeKeys[NextIndex].timeStamp - animatedNode->m_nodeKeys[Index].timeStamp;
+        if (DeltaTime == 0.0f) {
+            Out = animatedNode->m_nodeKeys[Index].scale;
+            return;
+        }
         float Factor = (AnimationTime - animatedNode->m_nodeKeys[Index].timeStamp) / DeltaTime;
 
         glm::vec3 start = animatedNode->m_nodeKeys[Index].scale;
@@ -75,6 +97,11 @@ namespace Util {
     }
 
     void CalcInterpolatedRotation(glm::quat& Out, float AnimationTime, const AnimatedNode* animatedNode) {
+        if (!animatedNode || animatedNode->m_nodeKeys.empty()) {
+            Out = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            return;
+        }
+
         int Index = FindAnimatedNodeIndex(AnimationTime, animatedNode);
         int NextIndex = (Index + 1);
 
@@ -90,6 +117,10 @@ namespace Util {
             return;
         }
         float DeltaTime = animatedNode->m_nodeKeys[NextIndex].timeStamp - animatedNode->m_nodeKeys[Index].timeStamp;
+        if (DeltaTime == 0.0f) {
+            Out = animatedNode->m_nodeKeys[Index].rotation;
+            return;
+        }
         float Factor = (AnimationTime - animatedNode->m_nodeKeys[Index].timeStamp) / DeltaTime;
 
         const glm::quat& StartRotationQ = animatedNode->m_nodeKeys[Index].rotation;

--- a/Hell2025/Hell2025/src/World/World.cpp
+++ b/Hell2025/Hell2025/src/World/World.cpp
@@ -128,7 +128,6 @@ namespace World {
         LoadMapInstancesHeightMapData(mapInstanceCreateInfoSet);
 
 
-        int i = 0;
         for (MapInstanceCreateInfo& mapInstanceCreateInfo : mapInstanceCreateInfoSet) {
             SpawnOffset spawnOffset;
             spawnOffset.translation.x = mapInstanceCreateInfo.spawnOffsetChunkX * HEIGHT_MAP_CHUNK_WORLD_SPACE_SIZE;
@@ -157,10 +156,6 @@ namespace World {
             //christmasTreeCreateInfo.position = glm::vec3(0.78f, 0.15f, 2.25f);
             //christmasTreeCreateInfo.rotation.y = Util::RandomFloat(0, HELL_PI);
             //AddChristmasTree(christmasTreeCreateInfo, spawnOffset);
-
-            Logging::Warning() << "MAKE SURE YOU REMOVE THIS LINE break IT IS DISABLING THE LOAD OF THE SECOND MAP INSTANCE";
-            break;
-            i++;
         }
 
         RecreateHouseMesh();


### PR DESCRIPTION
This PR fixes foundational correctness/stability issues: current-frame deltaTime ordering in BackEnd::UpdateGame, corrected MeshNode open/closed logic, consolidated GlobalIllumination mutable globals into explicit state context, hardened empty-vector/nullable upload paths, fixed FFT double time accumulation, and added a Windows MSVC CI build workflow.

Commit: 7c248f45